### PR TITLE
fix(lint): align Ruff 0.16 checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.1
+    rev: v0.16.0
     hooks:
       - id: ruff
         args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,12 @@ ignore = [
   "D203", # no-blank-line-before-class (incompatible with formatter)
   "D212", # multi-line-summary-first-line (incompatible with formatter)
   "COM812", # incompatible with formatter
+  "CPY001", # Project files do not require copyright headers
   "ISC001", # incompatible with formatter
+  "ISC004", # Allow readable multiline strings in collections
   "FIX002", # Line contains TODO, consider resolving an issue
   "TD003", # Missing issue link on the line following this TODO
+  "UP042", # Preserve existing Enum string behavior
   "RUF001", # Cyrillic text intentionally used
 ]
 


### PR DESCRIPTION
Align the pre-commit Ruff hook with the uv dependency and preserve the existing lint policy for rules introduced in Ruff 0.16.

Validated locally:
- scripts/lint
- uv run pre-commit run --all-files
- scripts/test (137 passed)