### PR TITLE
fix(ci): use v7 category schema

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,7 @@ categories:
       - fix
       - bug
   - title: 🧰 Maintenance
-    label:
+    labels:
       - chore
       - dependencies
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"


### PR DESCRIPTION
Release Drafter v7 requires `labels` for a category label list. The singular `label` key caused the main workflow to fail schema validation.

Validated locally with the repository YAML pre-commit hook.